### PR TITLE
Add continuous integration via travis-ci

### DIFF
--- a/.ci/test_script.sh
+++ b/.ci/test_script.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# try cifs
+cd cifs
+for cif in *.cif; do
+    cif2cell $cif
+done
+
+# try periodic table
+cd periodic_table
+for cif in *.cif; do
+    cif2cell $cif
+done

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+
+python:
+  - "3.6"
+  - "2.7"
+
+install:
+  - pip install -e .
+
+script:
+  - cif2cell --help
+  - .ci/test_script.sh

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(name='cif2cell',
       scripts=['binaries/cif2cell', 'binaries/vasp2cif'],
       install_requires=[
           "six",
-          "PyCifRW==4.2.1; python_version < '3'",
+          "PyCifRW<4; python_version < '3'",
           "PyCifRW==4.4; python_version >= '3'",
       ],
       packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(name='cif2cell',
       url='http://cif2cell.sourceforge.net/',
       scripts=['binaries/cif2cell', 'binaries/vasp2cif'],
       install_requires=[
+          "six",
           "PyCifRW==4.2.1; python_version < '3'",
           "PyCifRW==4.4; python_version >= '3'",
       ],


### PR DESCRIPTION
This PR adds a continuous integration test that runs on every new commit

The test checks on both python 2.7 and 3.6 that:
 * cif2cell can be installed
 * cif2cell --help works
 * cif2cell can successfully run on all cif files in the `cifs` directory

@torbjornbjorkman you see the successful run on my fork here:
https://travis-ci.org/ltalirz/cif2cell

In order to enable this on your repository as well, please register on travis-ci.org using your github account and click the button to enable continuous integration tests for this repository