### PR TITLE
Make the output of 'cif2cell --help' deterministic

### DIFF
--- a/binaries/cif2cell
+++ b/binaries/cif2cell
@@ -61,7 +61,7 @@ vcaprograms = set(["castep","vasp"])
 #
 setupallprogs = set(["vasp","pwscf","quantum-espresso","rspt","mopac"])
 setupallstring = ""
-for p in setupallprogs:
+for p in sorted(list(setupallprogs)):
     setupallstring += p+", "
 setupallstring = setupallstring.rstrip(", ")
 #


### PR DESCRIPTION
Currently, calls to `cif2cell --help` result in different outputs. This PR sorts set items prior to printing them.