### PR TITLE
reduce wildcard imports

### DIFF
--- a/binaries/cif2cell
+++ b/binaries/cif2cell
@@ -22,16 +22,20 @@
 #  Author:      Torbjorn Bjorkman
 #  ORCID:       0000-0002-1154-9846
 #************************************************************************************
+import sys
+import os
+import string
 import copy
 from datetime import datetime
 from optparse import OptionParser, OptionGroup
 import warnings
-from math import acos
+from math import acos, pi
 
 import CifFile
 from cif2cell.ESPInterfaces import *
 from cif2cell.elementdata import ElementData
-from cif2cell.utils import safe_matheval, PositionError, SymmetryError, CellError, SurfaceWizard, angtobohr, codename, uperautogpercm
+from cif2cell.utils import safe_matheval, PositionError, SymmetryError, CellError, SurfaceWizard, angtobohr, codename, \
+    uperautogpercm, SetupError, LatticeMatrix, minv3, Vector, mmmult3
 from cif2cell.uctools import ReferenceData, CellData, SymmetryOperation
 
 # Name and version

--- a/binaries/cif2cell
+++ b/binaries/cif2cell
@@ -22,26 +22,23 @@
 #  Author:      Torbjorn Bjorkman
 #  ORCID:       0000-0002-1154-9846
 #************************************************************************************
-import os
-import sys
-import string
 import copy
-from math import *
 from datetime import datetime
 from optparse import OptionParser, OptionGroup
 import warnings
+from math import acos
+
 import CifFile
-import subprocess
-from cif2cell.utils import *
-from cif2cell.uctools import *
 from cif2cell.ESPInterfaces import *
-from cif2cell.elementdata import *
+from cif2cell.elementdata import ElementData
+from cif2cell.utils import safe_matheval, PositionError, SymmetryError, CellError, SurfaceWizard, angtobohr, codename, uperautogpercm
+from cif2cell.uctools import ReferenceData, CellData, SymmetryOperation
 
 # Name and version
 programname = "cif2cell"
 version = "2.0.0"
 
-# Turn of warnings about deprecated stuff
+# Turn off warnings about deprecated stuff
 warnings.simplefilter("ignore",DeprecationWarning)
 
 # All supported output formats

--- a/binaries/vasp2cif
+++ b/binaries/vasp2cif
@@ -51,7 +51,6 @@ import sys
 import subprocess
 import math
 import re
-from math import copysign
 from subprocess import Popen, call, PIPE
 from optparse import OptionParser
 

--- a/cif2cell/ESPInterfaces.py
+++ b/cif2cell/ESPInterfaces.py
@@ -34,6 +34,47 @@ from cif2cell.utils import Vector, LatticeMatrix, mvmult3, deletenewline, AtomSi
 from cif2cell.elementdata import ElementData
 from cif2cell.spacegroupdata import Number2AP
 
+__all__ = (
+    'GeometryOutputFile',
+    'ATATFile',
+    'HUTSEPOTFile',
+    'ASEFile',
+    'CFGFile',
+    'COOFile',
+    'LAMMPSFile',
+    'XYZFile',
+    'OldNCOLFile',
+    'BSTRFile',
+    'CellgenFile',
+    'SymtFile',
+    'SymtFile2',
+    'Crystal09File',
+    'SpacegroupFile',
+    'ElkFile',
+    'ExcitingFile',
+    'FleurFile',
+    'CASTEPFile',
+    'PWSCFFile',
+    'CP2KFile',
+    'CPMDFile',
+    'SiestaFile',
+    'ABINITFile',
+    'AIMSFile',
+    'MCSQSFile',
+    'POSCARFile',
+    'POTCARFile',
+    'KPOINTSFile',
+    'INCARFile',
+    'KFCDFile',
+    'KGRNFile',
+    'ShapeFile',
+    'BMDLFile',
+    'KSTRFile',
+    'XBandSysFile',
+    'SPCFile',
+    'MOPACFile',
+)
+
 ################################################################################################
 ed = ElementData()
 suspiciouslist = set(["Cr", "Mn", "Fe", "Co", "Ni",

--- a/cif2cell/ESPInterfaces.py
+++ b/cif2cell/ESPInterfaces.py
@@ -23,15 +23,16 @@
 #  Author:      Torbjorn Bjorkman
 #  ORCID:       0000-0002-1154-9846
 # ******************************************************************************************
-import copy
 import os
 import math
 import string
-from cif2cell.utils import *
-from cif2cell.elementdata import *
-from cif2cell.uctools import *
+from math import pi, sin, cos
+import sys
 from re import search
 
+from cif2cell.utils import Vector, LatticeMatrix, mvmult3, deletenewline, AtomSite, SetupError, det3, minv3, third, mmmult3
+from cif2cell.elementdata import ElementData
+from cif2cell.spacegroupdata import Number2AP
 
 ################################################################################################
 ed = ElementData()

--- a/cif2cell/uctools.py
+++ b/cif2cell/uctools.py
@@ -27,20 +27,16 @@
 #  ORCID:       0000-0002-1154-9846
 #
 # ******************************************************************************************
-import os
 import sys
 import string
 import copy
-import CifFile
-from types import *
-from math import sin, cos, pi, sqrt, pow, ceil, floor
-from cif2cell.utils import *
+from math import sin, cos, pow, gcd
 from random import random, gauss
-from math import gcd
-from cif2cell.spacegroupdata import *
-from cif2cell.elementdata import *
-if sys.version_info >= (3, 0):
-    from functools import reduce
+from functools import reduce
+
+from cif2cell.utils import *
+from cif2cell.spacegroupdata import Hex2RhombHall, Number2Hall, HM2Hall, Hall2Number, Rhomb2HexHall, Hall2HM, SymOpsHall
+from cif2cell.elementdata import ElementData
 
 ################################################################################################
 

--- a/cif2cell/utils.py
+++ b/cif2cell/utils.py
@@ -22,7 +22,7 @@
 #
 #******************************************************************************************
 from math import sqrt,acos,pi
-from cif2cell.elementdata import *
+from cif2cell.elementdata import ElementData
 ################################################################################################
 # Miscellaneous
 zero = 0.0
@@ -216,7 +216,7 @@ class Vector(list,GeometryObject):
             t += self[i]*a[i]
         return t
     # triple product
-    def triple(self,a,b):
+    def triple(self,a,b,c):
         t = [a,b,c]
         return det3(t)
     # coordinate transformation


### PR DESCRIPTION
cif2cell was using wildcard imports from huge namespaces, making it easy
to accidentally overshadow/replace variables from a different namespace.