### PR TITLE
test on macos and windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,31 @@ jobs:
     - name: Run test suite
       run: pytest
 
+  cross-platform:
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
+
+    strategy:
+      matrix:
+        python-version: [3.9]
+        os: ['macos-10.15', 'windows-2019']
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install cif2cell
+      run: |
+        pip install -e .[tests]
+        pip freeze
+
+    - name: Check cli
+      run: cif2cell --help
+
+    - name: Run test suite
+      run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel"]

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ ciffiles = glob('cifs/*.cif')
 periodiccifs = glob('cifs/periodic_table/*.cif')+['cifs/periodic_table/README']
 
 setup(name='cif2cell',
-      version='2.0.0a3',
+      version='2.0.0a4',
       description='Construct a unit cell from CIF data',
       long_description=open('README.md').read(),
       long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(name='cif2cell',
       scripts=['binaries/cif2cell', 'binaries/vasp2cif'],
       python_requires=">=3.6",
       install_requires=[
-          "PyCifRW==4.4",
+          "PyCifRW~==4.4.0",
       ],
       packages=find_packages(),
       data_files=[('lib/cif2cell', ['LICENSE']),

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(name='cif2cell',
       scripts=['binaries/cif2cell', 'binaries/vasp2cif'],
       python_requires=">=3.6",
       install_requires=[
-          "PyCifRW~==4.4.0",
+          "PyCifRW~=4.4.0",
       ],
       packages=find_packages(),
       data_files=[('lib/cif2cell', ['LICENSE']),

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with cif2cell.  If not, see <http://www.gnu.org/licenses/>.
 #
-from setuptools import setup, find_packages
 from glob import glob
+from setuptools import setup, find_packages
 
 # Set up documentation
 docfiles = ['docs/cif2cell.pdf']
@@ -25,7 +25,7 @@ ciffiles = glob('cifs/*.cif')
 periodiccifs = glob('cifs/periodic_table/*.cif')+['cifs/periodic_table/README']
 
 setup(name='cif2cell',
-      version='2.0.0a4',
+      version='2.0.0a5',
       description='Construct a unit cell from CIF data',
       long_description=open('README.md').read(),
       long_description_content_type='text/markdown',

--- a/tests/test_cif2cell.py
+++ b/tests/test_cif2cell.py
@@ -15,7 +15,12 @@ def run_cif2cell(args):
     else:
         cmd = [ CIF2CELL_SCRIPT ] + args
 
-    return subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode('utf8')
+    try:
+        result = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode('utf8')
+        return result
+    except subprocess.CalledProcessError as e:
+        raise EnvironmentError(result) from e
+
 
 @pytest.mark.parametrize("cif_file", CIF_FILES)
 def test_parse(cif_file):

--- a/tests/test_cif2cell.py
+++ b/tests/test_cif2cell.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import subprocess
 import platform
+import os
 import sys
 import pytest
 
@@ -17,10 +18,10 @@ def run_cif2cell(args):
         cmd = [ CIF2CELL_SCRIPT ] + args
 
     try:
-        result = subprocess.check_output(cmd, stderr=subprocess.STDOUT, encoding=sys.getdefaultencoding())
+        result = subprocess.check_output(cmd, stderr=subprocess.STDOUT, env=dict(os.environ, PYTHONIOENCODING='utf8'), encoding='utf8')
         return result
-    except subprocess.CalledProcessError as e:
-        raise EnvironmentError(result) from e
+    except subprocess.CalledProcessError as exc:
+        raise EnvironmentError(result) from exc
 
 
 @pytest.mark.parametrize("cif_file", CIF_FILES)

--- a/tests/test_cif2cell.py
+++ b/tests/test_cif2cell.py
@@ -1,8 +1,8 @@
+"""Tests for cif2cell."""
 from pathlib import Path
 import subprocess
 import platform
 import os
-import sys
 import pytest
 
 TEST_DIR = Path(__file__).resolve().parent
@@ -18,7 +18,12 @@ def run_cif2cell(args):
         cmd = [ CIF2CELL_SCRIPT ] + args
 
     try:
-        result = subprocess.check_output(cmd, stderr=subprocess.STDOUT, env=dict(os.environ, PYTHONIOENCODING='utf8'), encoding='utf8')
+        # Setting the PYTHONIOENCODING was necessary for windows runners on GitHub action
+        result = subprocess.check_output(
+            cmd,
+            stderr=subprocess.STDOUT,
+            env=dict(os.environ, PYTHONIOENCODING='utf8'),
+            encoding='utf8')
         return result
     except subprocess.CalledProcessError as exc:
         raise EnvironmentError(result) from exc

--- a/tests/test_cif2cell.py
+++ b/tests/test_cif2cell.py
@@ -1,7 +1,7 @@
-import pytest
-import subprocess
 from pathlib import Path
+import subprocess
 import platform
+import pytest
 
 TEST_DIR = Path(__file__).resolve().parent
 CIFS_DIR = TEST_DIR.parent / 'cifs'
@@ -16,7 +16,7 @@ def run_cif2cell(args):
         cmd = [ CIF2CELL_SCRIPT ] + args
 
     try:
-        result = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode('utf8')
+        result = subprocess.check_output(cmd, stderr=subprocess.STDOUT, encoding='utf8').decode('utf8')
         return result
     except subprocess.CalledProcessError as e:
         raise EnvironmentError(result) from e

--- a/tests/test_cif2cell.py
+++ b/tests/test_cif2cell.py
@@ -1,24 +1,18 @@
-
-import glob
-import os
-import sys
 import pytest
 import subprocess
+from pathlib import Path
 
-TEST_DIR = os.path.dirname(os.path.realpath(__file__))
-CIFS_DIR = os.path.join( os.path.join(TEST_DIR, os.path.pardir, 'cifs') )
-CIF_FILES = glob.glob(os.path.join(CIFS_DIR, '*.cif'))
+TEST_DIR = Path(__file__).resolve().parent
+CIFS_DIR = TEST_DIR.parent / 'cifs'
+CIF_FILES = CIFS_DIR.glob('*.cif')
+CIF2CELL_SCRIPT = TEST_DIR.parent / 'binaries' / 'cif2cell'
 
 def run_cif2cell(args):
-    return subprocess.check_output(['./binaries/cif2cell'] + args, stderr=subprocess.STDOUT).decode('utf8')
+    return subprocess.check_output([CIF2CELL_SCRIPT] + args, stderr=subprocess.STDOUT).decode('utf8')
 
 @pytest.mark.parametrize("cif_file", CIF_FILES)
 def test_parse(cif_file):
     """Test running cif2cell on each CIF file in /cifs."""
-    if sys.version_info < (3,0) and 'SiC.cif' in cif_file:
-        pytest.skip(msg='skip test for files with unicode content under python 2.7.' +
-           'see https://github.com/torbjornbjorkman/cif2cell/issues/7')
-
     result = run_cif2cell([cif_file])
 
     assert not "***Warning: Space group operation check failed" in result
@@ -26,15 +20,15 @@ def test_parse(cif_file):
 
 def test_vasp():
     """Test VASP output."""
-    cif_file = os.path.join(CIFS_DIR, "Si.cif")
+    cif_file = CIFS_DIR / "Si.cif"
     result = run_cif2cell(["-p", "vasp", "-f", cif_file])
     assert not "***Warning: Space group operation check failed" in result
     assert not "Error" in result
-    assert os.path.exists("POSCAR")
+    assert Path("POSCAR").exists()
 
 def test_castep():
     """Test CASTEP output."""
-    cif_file = os.path.join(CIFS_DIR, "Si.cif")
+    cif_file = CIFS_DIR / "Si.cif"
     result = run_cif2cell(["-p", "castep", "-f", cif_file])
 
     assert not "***Warning: Space group operation check failed" in result

--- a/tests/test_cif2cell.py
+++ b/tests/test_cif2cell.py
@@ -1,13 +1,21 @@
 import pytest
 import subprocess
 from pathlib import Path
+import platform
 
 TEST_DIR = Path(__file__).resolve().parent
 CIFS_DIR = TEST_DIR.parent / 'cifs'
 CIF_FILES = CIFS_DIR.glob('*.cif')
+CIF2CELL_SCRIPT = TEST_DIR.parent / 'binaries' / 'cif2cell'
 
 def run_cif2cell(args):
-    return subprocess.check_output(["cif2cell"] + args, stderr=subprocess.STDOUT).decode('utf8')
+    if platform.system() == 'Windows':
+        # windows does not understand the shebang
+        cmd = ["python.exe", CIF2CELL_SCRIPT] + args
+    else:
+        cmd = [ CIF2CELL_SCRIPT ] + args
+
+    return subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode('utf8')
 
 @pytest.mark.parametrize("cif_file", CIF_FILES)
 def test_parse(cif_file):

--- a/tests/test_cif2cell.py
+++ b/tests/test_cif2cell.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import subprocess
 import platform
+import sys
 import pytest
 
 TEST_DIR = Path(__file__).resolve().parent
@@ -16,7 +17,7 @@ def run_cif2cell(args):
         cmd = [ CIF2CELL_SCRIPT ] + args
 
     try:
-        result = subprocess.check_output(cmd, stderr=subprocess.STDOUT, encoding='utf8')
+        result = subprocess.check_output(cmd, stderr=subprocess.STDOUT, encoding=sys.getdefaultencoding())
         return result
     except subprocess.CalledProcessError as e:
         raise EnvironmentError(result) from e

--- a/tests/test_cif2cell.py
+++ b/tests/test_cif2cell.py
@@ -16,7 +16,7 @@ def run_cif2cell(args):
         cmd = [ CIF2CELL_SCRIPT ] + args
 
     try:
-        result = subprocess.check_output(cmd, stderr=subprocess.STDOUT, encoding='utf8').decode('utf8')
+        result = subprocess.check_output(cmd, stderr=subprocess.STDOUT, encoding='utf8')
         return result
     except subprocess.CalledProcessError as e:
         raise EnvironmentError(result) from e

--- a/tests/test_cif2cell.py
+++ b/tests/test_cif2cell.py
@@ -5,10 +5,9 @@ from pathlib import Path
 TEST_DIR = Path(__file__).resolve().parent
 CIFS_DIR = TEST_DIR.parent / 'cifs'
 CIF_FILES = CIFS_DIR.glob('*.cif')
-CIF2CELL_SCRIPT = TEST_DIR.parent / 'binaries' / 'cif2cell'
 
 def run_cif2cell(args):
-    return subprocess.check_output([CIF2CELL_SCRIPT] + args, stderr=subprocess.STDOUT).decode('utf8')
+    return subprocess.check_output(["cif2cell"] + args, stderr=subprocess.STDOUT).decode('utf8')
 
 @pytest.mark.parametrize("cif_file", CIF_FILES)
 def test_parse(cif_file):


### PR DESCRIPTION
It turns out that without a `pyproject.toml` the installation of `pycifrw` will not use the existing `pycifrw` wheels (which leads to installation failures on macos).

by adding the pyproject.toml we get a build that works on linux and macos.