### PR TITLE
Added interface for crymol program

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ the primitive cell or the conventional cell.
 |               |         | in separate directories.|
 |spr-kkr        |   yes   | [compoundname].sys|
 |xyz            |   no    | [compoundname].xyz|
-
+|crymol (gnxas) |   no    | [compoundname]\_cry.in|
 
 ## CONTENTS
 

--- a/binaries/cif2cell
+++ b/binaries/cif2cell
@@ -31,8 +31,6 @@ from optparse import OptionParser, OptionGroup
 import warnings
 from math import acos, pi
 
-# for testing, remove before pushing
-sys.path.append( '../' )
 
 import CifFile
 from cif2cell.ESPInterfaces import *

--- a/binaries/cif2cell
+++ b/binaries/cif2cell
@@ -46,7 +46,7 @@ version = "2.0.0"
 warnings.simplefilter("ignore",DeprecationWarning)
 
 # All supported output formats
-outputprograms = set(['abinit','atat','castep','cfg','coo','cpmd','cp2k','crystal09','elk','emto','exciting','fhi-aims',
+outputprograms = set(['abinit','atat','castep','cfg','coo','cpmd','cp2k','crymol','crystal09','elk','emto','exciting','fhi-aims',
                       ## 'fleur','ncol','mcsqs','rspt','siesta','sprkkr','vasp', # mcsqs not ready
                       'fleur','hutsepot','lammps','mopac','ncol', 'pwscf', 'quantum-espresso', 'rspt','siesta','sprkkr','vasp',
                       'ase','bmdl','cellgen','cif','kgrn','kfcd','kstr','shape','spacegroup',
@@ -945,6 +945,8 @@ else:
             outputfile = outputfile+".xyz"
         elif outputprogram == "lammps":
         	outputfile = outputfile+".data"
+        elif outputprogram == "crymol":
+                outputfile = outputfile+"_cry.in"
         else:
             pass
 
@@ -1811,4 +1813,16 @@ if outputprogram == 'lammps':
     f.close()
     sys.exit(0)
 
-
+################################################################################################
+# Output for crymol file
+if outputprogram == 'crymol':
+    # The second comment line with info from the CIF file
+    docstring = StandardDocstring()
+    # for simplicity, conversion is done using only conventional cell input
+    cd.conventional()
+    # Initialize the CrymolFile structure
+    sysfile = CRYMOLFile(cd, docstring)
+    f = open(outputfile, outmode)
+    f.write(str(sysfile))
+    f.close()
+    sys.exit(0)

--- a/binaries/cif2cell
+++ b/binaries/cif2cell
@@ -31,6 +31,9 @@ from optparse import OptionParser, OptionGroup
 import warnings
 from math import acos, pi
 
+# for testing, remove before pushing
+sys.path.append( '../' )
+
 import CifFile
 from cif2cell.ESPInterfaces import *
 from cif2cell.elementdata import ElementData
@@ -212,7 +215,7 @@ if options.supercellmap and options.supercelldims:
     sys.stderr.write("***Error: cannot use both --supercell and --supercell-dimensions.\n")
     sys.exit(1)
 
-    
+
 #############################################################
 # INITIAL PARSING OF VARIOUS INPUT DATA
 # Electronic structure program
@@ -341,7 +344,7 @@ if cif_file:
     else:
         cif_grammar = '1.1'
     # Skip validation... it causes too much trouble.
-    ## cdic = CifFile.CifDic("cif_core.dic",grammar='1.1')     
+    ## cdic = CifFile.CifDic("cif_core.dic",grammar='1.1')
     ## val_results = CifFile.validate(cif_file,dic=cdic)
     ## print(validate_report(val_results))
     ## val_report = CifFile.ValidationResult(val_results)
@@ -365,7 +368,7 @@ if cif_file:
                         datamissing = True
                     counter += 1
             if datamissing:
-                tmpname = cif_file.replace('.cif','_tmp.cif') 
+                tmpname = cif_file.replace('.cif','_tmp.cif')
                 f = open(tmpname,'w')
                 f.write("data_default\n")
                 for line in lines:
@@ -426,7 +429,7 @@ if makesupercell:
         supercellpostvactransvec = safe_matheval(options.supercellpostvactransvec)
     else:
         supercellpostvactransvec = [0,0,0]
-    # 
+    #
     if options.supercellsort:
         supercellsort = options.supercellsort.lower()
     else:
@@ -509,7 +512,7 @@ if options.surfacewizardhkl:
     wizardstr = wizardstr.rstrip(',')+"]\n"
     sys.stdout.write(wizardstr)
     sys.exit()
-        
+
 ##############################################
 # Test if generated cell agrees with given chemical formula.
 # Too difficult for alloys (no universally agreed-upon way to write the formula into cifs).
@@ -640,7 +643,7 @@ if verbose or not options.program and not options.quiet:
                 w1 = max(w1,len(tmpstring1))
                 w3 = max(w3,len(tmpstring2))
                 w4 = max(w4,len(tmpstring3))
-        # small aesthetic adjustment 
+        # small aesthetic adjustment
         w1 = w1 + 1
         w3 = w3 + 2
         w4 = max(w4 + 2, 8)
@@ -757,7 +760,7 @@ if transformcell:
             if not force:
                 sys.stderr.write("          Use --force to go ahead anyway.\n")
                 sys.exit(1)
-            
+
     if options.rhombdiag:
         # Put z direction along pseudocubic [111]. Kind of the opposite of the cubediagz.
         t = 1/cd.latticevectors[0].length()   # Normalization to 1
@@ -816,12 +819,12 @@ if makesupercell:
             sys.stderr.write("***Error: random displacements: "+e.value+"\n")
             sys.exit(3)
         cd.symops = set([SymmetryOperation(['x','y','z'])])
-    
+
     # Print supercell
     if verbose or not options.program and not options.quiet:
         sys.stdout.write("\n SUPERCELL INFORMATION\n")
         cd.printCell(printcart=options.printcart, printdigits=printdigits, printcharges=options.printcharges)
-        
+
 if printsymops or printseitz or verbose:
     # Print symmetry operations. Need to make list of it to control order.
     symoplist = sorted(list(cd.symops))
@@ -846,7 +849,7 @@ if printsymops or printseitz or verbose:
                 tmpstring += fourdecs%(op.rotation[j][0],op.rotation[j][1],op.rotation[j][2],op.translation[j])+"\n"
             tmpstring += fourdecs%(0,0,0,1)
             sys.stdout.write(tmpstring)
-            i += 1    
+            i += 1
 
 # Remind that the result may be junk when using --force
 if force:
@@ -964,7 +967,7 @@ if cd.alloy and forcealloy and options.program and not verbose:
     else:
         tmpstring += "Warning! The file(s) will be incomplete!"
         sys.stdout.write(tmpstring+"\n")
-    
+
 ################################################################################################
 # Stop here if no specific output was requested
 if not options.program:
@@ -999,7 +1002,7 @@ if options.vca:
         sys.stderr.write("Warning: You are setting up a VCA calculation for an alloy with more than two components.\n         Make sure that you know what you are doing!\n")
     elif vcawarning2:
         sys.stderr.write("Warning: You are setting up a VCA calculation but not all alloy sites are occupied by species\n         from neighbouring groups in the periodic table. Make sure that you know what you are doing!\n")
-        
+
 # Function for printing a standard docstring
 def StandardDocstring():
     cif2cellstring = ' T. Bjorkman, Comp. Phys. Commun. 182, 1183-1186 (2011). Please cite generously.'
@@ -1108,7 +1111,7 @@ if outputprogram == 'abinit':
     f = open(outputfile, outmode)
     f.write(str(abinitinput))
     f.close()
-    
+
 ################################################################################################
 # Output for ATAT
 if outputprogram == 'atat':
@@ -1117,11 +1120,11 @@ if outputprogram == 'atat':
     f = open(outputfile, outmode)
     f.write(str(abinitinput))
     f.close()
-    
+
 ################################################################################################
 # Output for ASE file (python script)
 if outputprogram == 'ase':
-    # The second comment line with info from the CIF file 
+    # The second comment line with info from the CIF file
     docstring = StandardDocstring()
     # Initialize the ASEFile structure
     sysfile = ASEFile(cd, docstring)
@@ -1146,7 +1149,7 @@ if outputprogram == 'castep':
     f = open(outputfile, outmode)
     f.write(str(castepinput))
     f.close()
-    
+
 ################################################################################################
 # Output to cfg file
 if outputprogram == 'cfg':
@@ -1178,7 +1181,7 @@ if outputprogram == 'cp2k':
     f = open(outputfile, outmode)
     f.write(str(cp2kinput))
     f.close()
-    
+
 ################################################################################################
 # Output for CPMD
 if outputprogram == 'cpmd':
@@ -1187,7 +1190,7 @@ if outputprogram == 'cpmd':
     f = open(outputfile, outmode)
     f.write(str(cpmdinput))
     f.close()
-    
+
 ################################################################################################
 # Output for Crystal09
 if outputprogram == 'crystal09':
@@ -1196,7 +1199,7 @@ if outputprogram == 'crystal09':
     # Crystal09 wants conventional cell input, unless specifically asked to for possible
     # rhombohedral settings.
     if cd.is_spacegroup("rhombohedral") and options.crystal09rhombohedral:
-        cd.primitive()            
+        cd.primitive()
     else:
         cd.conventional()
     # Get output file object
@@ -1392,7 +1395,7 @@ if outputprogram == 'kfcd' or outputprogram == 'emto':
     f.write(str(kfcdfile))
     f.close()
     if outputprogram == "kfcd":
-        sys.exit(0)        
+        sys.exit(0)
 if outputprogram == "emto":
     sys.exit(0)
 
@@ -1474,7 +1477,7 @@ if outputprogram == 'fleur':
     f = open(outputfile, outmode)
     f.write(str(fleurinput))
     f.close()
-    
+
 ################################################################################################
 # Output for mcsqs
 if outputprogram == 'mcsqs':
@@ -1516,11 +1519,11 @@ if outputprogram == 'mopac':
     f = open(outputfile, outmode)
     f.write(str(mopacinput))
     f.close()
-    
+
 ################################################################################################
 # Output for TB-LMTO program ncol
 if outputprogram == 'ncol' or outputprogram == 'bstr':
-    # Set up names for files. 
+    # Set up names for files.
     if cd.HMSymbol == "":
         bstrjobnam = ref.cpd.replace(" ", "").replace("(","").replace(")","")
     else:
@@ -1538,7 +1541,7 @@ if outputprogram == 'ncol' or outputprogram == 'bstr':
     docstring = ref.compound+", "+ref.referencestring()
     # Document details of creation
     programdoc = "Generated by "+programname+" "+version+" "+datestring
-        
+
 # Output for TB-LMTO structure constant program bstr
 if outputprogram == 'bstr' or outputprogram == 'ncol':
     # Initialize BSTRFile
@@ -1590,7 +1593,7 @@ if outputprogram == 'pwscf':
     f = open(outputfile, outmode)
     f.write(str(pwscfinput))
     f.close()
-    
+
 ################################################################################################
 # Output for VASP
 if outputprogram == 'vasp':
@@ -1663,7 +1666,7 @@ if outputprogram == 'vasp':
         f.write(str(incarfile))
         f.close()
     sys.exit(0)
-    
+
 ################################################################################################
 # Output for RSPt
 if outputprogram == 'rspt':
@@ -1686,7 +1689,7 @@ if outputprogram == 'rspt':
             symtfile.forcenospin = True
     else:
         symtfile = SymtFile(cd, docstring)
-    # spin axis 
+    # spin axis
     if options.rsptspinaxis:
         symtfile.spinaxis = Vector(safe_matheval(options.rsptspinaxis))
     if options.rsptpasswyckoff:
@@ -1700,7 +1703,7 @@ if outputprogram == 'rspt':
     f.write(str(symtfile))
     f.close()
     sys.exit(0)
-    
+
 # Output for RSPt supercell generator cellgen
 if outputprogram == 'cellgen':
     # Construct documentation string
@@ -1735,11 +1738,11 @@ if outputprogram == 'siesta':
     f = open(outputfile, outmode)
     f.write(str(siestainput))
     f.close()
-    
+
 ################################################################################################
 # Output for SPC file
 if outputprogram == 'spc':
-    # The second comment line with info from the CIF file 
+    # The second comment line with info from the CIF file
     docstring = StandardDocstring()
     # Initialize the SPCFile structure
     sysfile = SPCFile(cd, docstring)
@@ -1770,11 +1773,11 @@ if outputprogram == 'xband' or outputprogram == 'sprkkr':
     f.write(str(sysfile))
     f.close()
     sys.exit(0)
-    
+
 ################################################################################################
 # Output for xyz file
 if outputprogram == 'xyz':
-    # The second comment line with info from the CIF file 
+    # The second comment line with info from the CIF file
     docstring =  "Generated by "+programname+" "+version
     if ref.database != "" and ref.databasecode != "" and ref.databasecode is not None:
         docstring += " from "+ref.databaseabbr[ref.database]+" reference: "+ref.databasecode
@@ -1796,7 +1799,7 @@ if outputprogram == 'xyz':
 ################################################################################################
 # Output for LAMMPS file
 if outputprogram == 'lammps':
-    # The second comment line with info from the CIF file 
+    # The second comment line with info from the CIF file
     docstring =  "Generated by "+programname+" "+version
     if ref.database != "" and ref.databasecode != "" and ref.databasecode is not None:
         docstring += " from "+ref.databaseabbr[ref.database]+" reference: "+ref.databasecode
@@ -1821,7 +1824,7 @@ if outputprogram == 'crymol':
     # for simplicity, conversion is done using only conventional cell input
     cd.conventional()
     # Initialize the CrymolFile structure
-    sysfile = CRYMOLFile(cd, docstring)
+    sysfile = CRYMOLFile(cd, docstring, ref.compound)
     f = open(outputfile, outmode)
     f.write(str(sysfile))
     f.close()

--- a/cif2cell/ESPInterfaces.py
+++ b/cif2cell/ESPInterfaces.py
@@ -73,7 +73,7 @@ __all__ = (
     'XBandSysFile',
     'SPCFile',
     'MOPACFile',
-    'CRYMOLFile'
+    'CRYMOLFile',
 )
 
 ################################################################################################
@@ -562,7 +562,7 @@ class XYZFile(GeometryOutputFile):
     and the method __str__ that outputs the contents of the .xyz file as a string.
     """
 
-    def __init__(self, crystalstructure, string)
+    def __init__(self, crystalstructure, string):
         GeometryOutputFile.__init__(self, crystalstructure, string)
         # To be put on the second line
         self.programdoc = ""

--- a/cif2cell/ESPInterfaces.py
+++ b/cif2cell/ESPInterfaces.py
@@ -3412,18 +3412,18 @@ class CRYMOLFile(GeometryOutputFile):
                 index += 1
         filestring += "NNY\n"
         filestring += "1\n"
-        filestring += "'*' '*' 2.2\n"
+        filestring += "'*' '*' [cut-off distance for first neighbors]\n"
         filestring += "7.0\n"
-        filestring += "out   ! 3 letters name for output file\n"
-        filestring += "1,1\n"
+        filestring += "[3 letters name for output files]\n"
+        filestring += "1,[index of photo-absorbing atom]\n"
         filestring += "0.10\n"
+        filestring += "[photo-absorption process: 1 for K-edge, 2 for L1-edge, etc.]\n"
         filestring += "1\n"
-        filestring += "1\n"
-        filestring += "CIP,0. [insert Core ionization energy in Ry!]\n"
+        filestring += "[Core ionization energy in Ry],0.\n"
         filestring += "3,-0.2,120.0,0.04\n"
         filestring += "5,-1\n"
         filestring += "'S',1,50.,15.,'S',' ','S'\n\n"
         filestring += self.docstring
-        filestring += "!cif2cell only convert the geometrical structure, remember to change the other parameters!"
+        filestring += "! Remember to insert missing parameters (indicated by []) !"
 
         return filestring

--- a/cif2cell/ESPInterfaces.py
+++ b/cif2cell/ESPInterfaces.py
@@ -73,6 +73,7 @@ __all__ = (
     'XBandSysFile',
     'SPCFile',
     'MOPACFile',
+    'CRYMOLFile'
 )
 
 ################################################################################################
@@ -561,7 +562,7 @@ class XYZFile(GeometryOutputFile):
     and the method __str__ that outputs the contents of the .xyz file as a string.
     """
 
-    def __init__(self, crystalstructure, string):
+    def __init__(self, crystalstructure, string)
         GeometryOutputFile.__init__(self, crystalstructure, string)
         # To be put on the second line
         self.programdoc = ""
@@ -3360,4 +3361,48 @@ class MOPACFile(GeometryOutputFile):
         # Print lattice vectors
         for l in lv:
             filestring += "Tv  "+str(l)+"\n"
+        return filestring
+
+################################################################################################
+# GNXAS CRYMOL FILE
+
+class CRYMOLFile(GeometryOutputFile):
+    """
+    Class for storing the geometrical data needed for outputting an input file
+    for crymol program of the GNXAS package and the method __str__ that outputs
+    the contents of the file as a string.
+    """
+
+    def __init__(self, crystalstructure, string):
+        GeometryOutputFile.__init__(self, crystalstructure, string)
+        # Document string on last line after
+        self.programdoc = ""
+
+    def __str__(self):
+        filestring = "CRY\n"
+        filestring += "\n"
+        if self.cell.crystal_system() == 'cubic':
+            filestring += "C\n"+str(self.cell.a)+"\n"
+        elif self.cell.crystal_system() == 'hexagonal':
+            filestring += "H\n"+str(self.cell.a)+", "+str(self.cell.c)+"\n"
+        elif self.cell.crystal_system() == 'tetragonal':
+            filestring += "E\n"+str(self.cell.a)+", "+str(self.cell.c)+"\n"
+        elif self.cell.crystal_system() == 'orthorhombic':
+            filestring += "O\n"+str(self.cell.a)+", "+str(self.cell.b)+", "+str(self.cell.c)+"\n"
+        elif self.cell.crystal_system() == 'trigonal':
+            filestring += "R\n"+str(self.cell.a)+"\n"+str(self.cell.alpha)+"\n"
+        elif self.cell.crystal_system() == 'monoclinic':
+            filestring += "M\n"+str(self.cell.a)+", "+str(self.cell.b)+", "+str(self.cell.c)+"\n"+str(self.cell.beta)+"\n"
+        elif self.cell.crystal_system() == 'triclinic':
+            filestring += "T\n"+str(self.cell.a)+", "+str(self.cell.b)+", "+str(self.cell.c)+"\n"+str(self.cell.alpha)+", "+str(self.cell.beta)+", "+str(self.cell.gamma)+"\n"
+        else:
+            raise SetupError("No support for " +
+                  self.crystal_system()+" crystal systems in crymol.")
+
+        filestring += "%i\n" % (self.cell.natoms())
+        index = 1
+        width = 2
+        for a in self.cell.atomdata:
+            for b in a:
+                filestring += "'"+b.spcstring().rjust(width)+"'  "+str(b.position)+" 12 0.0 0.0\n"
         return filestring

--- a/cif2cell/ESPInterfaces.py
+++ b/cif2cell/ESPInterfaces.py
@@ -3373,14 +3373,15 @@ class CRYMOLFile(GeometryOutputFile):
     the contents of the file as a string.
     """
 
-    def __init__(self, crystalstructure, string):
+    def __init__(self, crystalstructure, string, compound):
         GeometryOutputFile.__init__(self, crystalstructure, string)
         # Document string on last line after
         self.programdoc = ""
+        self.compound = compound
 
     def __str__(self):
         filestring = "CRY\n"
-        filestring += "\n"
+        filestring += self.compound+"\n"
         if self.cell.crystal_system() == 'cubic':
             filestring += "C\n"+str(self.cell.a)+"\n"
         elif self.cell.crystal_system() == 'hexagonal':
@@ -3392,9 +3393,11 @@ class CRYMOLFile(GeometryOutputFile):
         elif self.cell.crystal_system() == 'trigonal':
             filestring += "R\n"+str(self.cell.a)+"\n"+str(self.cell.alpha)+"\n"
         elif self.cell.crystal_system() == 'monoclinic':
-            filestring += "M\n"+str(self.cell.a)+", "+str(self.cell.b)+", "+str(self.cell.c)+"\n"+str(self.cell.beta)+"\n"
+            filestring += "M\n"+str(self.cell.a)+", "+str(self.cell.b)+", " \
+                          +str(self.cell.c)+"\n"+str(self.cell.beta)+"\n"
         elif self.cell.crystal_system() == 'triclinic':
-            filestring += "T\n"+str(self.cell.a)+", "+str(self.cell.b)+", "+str(self.cell.c)+"\n"+str(self.cell.alpha)+", "+str(self.cell.beta)+", "+str(self.cell.gamma)+"\n"
+            filestring += "T\n"+str(self.cell.a)+", "+str(self.cell.b)+", "+str(self.cell.c)+"\n"\
+                          +str(self.cell.alpha)+", "+str(self.cell.beta)+", "+str(self.cell.gamma)+"\n"
         else:
             raise SetupError("No support for " +
                   self.crystal_system()+" crystal systems in crymol.")
@@ -3404,5 +3407,23 @@ class CRYMOLFile(GeometryOutputFile):
         width = 2
         for a in self.cell.atomdata:
             for b in a:
-                filestring += "'"+b.spcstring().rjust(width)+"'  "+str(b.position)+" 12 0.0 0.0\n"
+                filestring += str(index).rjust(width)+"  '"+b.spcstring().rjust(width)\
+                             +"'  "+str(b.position)+" 12 0.0 0.0\n"
+                index += 1
+        filestring += "NNY\n"
+        filestring += "1\n"
+        filestring += "'*' '*' 2.2\n"
+        filestring += "7.0\n"
+        filestring += "out   ! 3 letters name for output file\n"
+        filestring += "1,1\n"
+        filestring += "0.10\n"
+        filestring += "1\n"
+        filestring += "1\n"
+        filestring += "CIP,0. [insert Core ionization energy in Ry!]\n"
+        filestring += "3,-0.2,120.0,0.04\n"
+        filestring += "5,-1\n"
+        filestring += "'S',1,50.,15.,'S',' ','S'\n\n"
+        filestring += self.docstring
+        filestring += "!cif2cell only convert the geometrical structure, remember to change the other parameters!"
+
         return filestring

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(name='cif2cell',
       scripts=['binaries/cif2cell', 'binaries/vasp2cif'],
       python_requires=">=3.6",
       install_requires=[
-          "PyCifRW==4.4",
+          "PyCifRW~=4.4",
       ],
       packages=find_packages(),
       data_files=[('lib/cif2cell', ['LICENSE']),


### PR DESCRIPTION
crymol is a program part of the GNXAS package for fitting EXAFS data (for more information, see [here](http://gnxas.unicam.it/pag_gnxas.html)). I am a contributor to the code.

As far as I know, there was no easy way to convert from a cif file to its input, so instead of creating one from zero, I added it to cif2cell, which I found by looking around for codes that converts cif files. I tested on the files inside cifs folder and it runs on all of them without problems (alloys are not supported, but using --force-alloy created a reasonable input file that can be easily modified). For simplicity, it just uses the conventional unit cell, in principle the use of the primitive unit cell is also possible, but require to insert also the symmetry operations in the input file and since for the purpose of the program the two are equivalent I didn't bother. 

I also removed all the trailing spaces in binaries/cif2cell because I have slight OCD :)

I would be happy if you consider adding it to the official repository. Thank you!