### PR TITLE
Castep cif label tag change ID->LABEL

### DIFF
--- a/cif2cell/ESPInterfaces.py
+++ b/cif2cell/ESPInterfaces.py
@@ -1609,7 +1609,7 @@ class CASTEPFile(GeometryOutputFile):
                 else:
                     filestring += b.spcstring().ljust(2)+" "+str(pos)
                 if self.printlabels and b.label != "":
-                    filestring += " ID="+b.label
+                    filestring += " LABEL="+b.label
                 filestring += "\n"
         if self.cartesian:
             filestring += "%ENDBLOCK POSITIONS_ABS\n"


### PR DESCRIPTION
Change the tag for CIF labels from ID to LABEL since Castep doesn't recognise the ID tag but does recognise LABEL.

Should fix issue https://github.com/torbjornbjorkman/cif2cell/issues/43